### PR TITLE
Remove services in the manifest command output

### DIFF
--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -195,6 +195,16 @@ Examples:
 			}
 		}
 
+		newLinks := make([]manifest.Link, 0, len(pub.Manifest.Links))
+		for _, link := range pub.Manifest.Links {
+			if strings.HasPrefix(link.Href.String(), "~readium/") {
+				// Skip links to services
+				continue
+			}
+			newLinks = append(newLinks, link)
+		}
+		pub.Manifest.Links = newLinks
+
 		var jsonBytes []byte
 		if indentFlag == "" {
 			jsonBytes, err = json.Marshal(pub.Manifest)


### PR DESCRIPTION
Closes #21 

@mickael-menu Do you think we should have a cleaner way of doing this? I'm not sure if it's worthy of some new params in the go-toolkit