### PR TITLE
Fix CLI version output

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,7 +11,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:     "readium",
 	Short:   "Utilities for Readium Web Publications",
-	Version: version.Version,
+	Version: Version + " (go-toolkit " + version.Version + ")",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"runtime/debug"
+	"time"
+)
+
+const toolkitRepo = "github.com/readium/cli"
+
+var Version = "unknown"
+
+type vcsInfo struct {
+	VCS      string
+	Revision string
+	Time     string
+	Modified string
+}
+
+func init() {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if info.Main.Path == toolkitRepo && info.Main.Version != "(devel)" {
+			// This is the toolkit itself
+			Version = info.Main.Version
+		}
+		if info.Main.Path == toolkitRepo && Version == "unknown" {
+			// Try instead using vcs info
+			vcs := vcsInfo{}
+			for _, v := range info.Settings {
+				switch v.Key {
+				case "vcs":
+					vcs.VCS = v.Value
+				case "vcs.revision":
+					vcs.Revision = v.Value
+				case "vcs.time":
+					vcs.Time = v.Value
+				case "vcs.modified":
+					vcs.Modified = v.Value
+				}
+			}
+			vcsToVersion(vcs)
+		}
+	}
+}
+
+func vcsToVersion(vcs vcsInfo) {
+	if vcs.VCS != "git" || vcs.Revision == "" || vcs.Time == "" {
+		return
+	}
+
+	t, err := time.Parse(time.RFC3339, vcs.Time)
+	if err != nil {
+		return
+	}
+
+	Version = "v0.0.0-" + t.UTC().Format("20060102150405") + "-" + vcs.Revision[:12]
+	if vcs.Modified == "true" {
+		Version += "+dirty"
+	}
+}


### PR DESCRIPTION
Closes #30
`readium --version` output will now be, for example `readium version vX (go-toolkit vY)`