### PR TITLE
fix: fix version log

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -9,14 +9,16 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:     "readium",
-	Short:   "Utilities for Readium Web Publications",
-	Version: Version + " (go-toolkit " + version.Version + ")",
+	Use:   "readium",
+	Short: "Utilities for Readium Web Publications",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	if rootCmd.Version == "" {
+		rootCmd.Version = Version + " (go-toolkit " + version.Version + ")"
+	}
 	err := rootCmd.Execute()
 	if err != nil {
 		// Error is already printed to stderr by Cobra.


### PR DESCRIPTION
## Problem

`readium -v` or `readium version` would output

```
readium version unknown (go-toolkit v0.11.0)
```

## Now

After doing `make build && ./readium -v`, I get

```
readium version v0.4.1-0.20250917105946-b88dc06efc6b+dirty (go-toolkit v0.11.0)
```

Note that `go run cmd/main.go -v` will still show `readium version unknown (go-toolkit v0.11.0)`, likely bc of the `info.Main.Path` being `""` when running it that way

I don't know much about `go`, so this might be an incorrect way to fix this behavior, but it works!